### PR TITLE
Added command line option to use rosbag timestamp rather than header.stamp

### DIFF
--- a/rosbags2video/args.py
+++ b/rosbags2video/args.py
@@ -44,6 +44,7 @@ def argparser_common(which_output):
         type=float,
         help="Rostime representing where to start in the bag.",
     )
+
     parser.add_argument(
         "--end",
         "-e",
@@ -59,6 +60,12 @@ def argparser_common(which_output):
         action="store",
         default="INFO",
         help="Logging level. Default INFO.",
+    )
+
+    parser.add_argument(
+        "--bag-time",
+        action="store_true",
+        help="Use bagfile time rather than header.stamp",
     )
 
     parser.add_argument(

--- a/rosbags2video/bag2images.py
+++ b/rosbags2video/bag2images.py
@@ -31,6 +31,7 @@ def write_frames(
     viz=False,
     encoding="bgr8",
     skip=1,
+    use_bagtime=False,
 ):
     convert = {topics[i]: i for i in range(len(topics))}
 
@@ -52,7 +53,11 @@ def write_frames(
         ):
             topic = connection.topic
             msg = bag_reader.deserialize(rawdata, connection.msgtype)
-            time = stamp_to_sec(msg.header.stamp)
+
+            if use_bagtime:
+                time = t / 1e9
+            else:
+                time = stamp_to_sec(msg.header.stamp)
 
             logging.debug("Topic %s updated at time %s seconds" % (topic, time))
 
@@ -114,6 +119,7 @@ def main():
             stop_time=stop_time,
             encoding=args.encoding,
             skip=args.skip,
+            use_bagtime=args.bag_time,
         )
 
         logging.info("Done.")

--- a/rosbags2video/bag2video.py
+++ b/rosbags2video/bag2video.py
@@ -28,6 +28,7 @@ def write_frames(
     start_time=0,
     stop_time=sys.maxsize,
     add_timestamp=False,
+    use_bagtime=False,
 ):
     convert = {topics[i]: i for i in range(len(topics))}
     frame_duration = 1.0 / fps
@@ -49,9 +50,14 @@ def write_frames(
     ):
         topic = connection.topic
         msg = bag_reader.deserialize(rawdata, connection.msgtype)
-        # print(f'DEBUG: {msg.header.stamp}')
+        # print(f'DEBUG: {msg.header.stamp}, {t}')
         # exit(0)
-        time = stamp_to_sec(msg.header.stamp)
+
+        if use_bagtime:
+            time = t / 1e9
+        else:
+            time = stamp_to_sec(msg.header.stamp)
+
         if init:
             image = message_to_cvimage(msg, encoding)
             images[convert[topic]] = image
@@ -181,6 +187,7 @@ def main():
             start_time=args.start,
             stop_time=args.end,
             add_timestamp=args.timestamp,
+            use_bagtime=args.bag_time,
         )
         logging.info("Done.")
         bag_reader.close()


### PR DESCRIPTION
I had a bagfile where the publisher was not correctly setting `header.stamp`.  

## Changes Made

Added an option `--bag-time` to use the bagfile time rather than `header.stamp`

## Testing

Tested with pathological ROS2 bagfile.