### PR TITLE
Use None for time limits rather than 0/maxsize, this does not work with sqlite3 bags

### DIFF
--- a/rosbags2video/args.py
+++ b/rosbags2video/args.py
@@ -1,5 +1,4 @@
 import argparse
-import sys
 import logging
 from pathlib import Path
 
@@ -40,7 +39,7 @@ def argparser_common(which_output):
         "--start",
         "-s",
         action="store",
-        default=0,
+        default=None,
         type=float,
         help="Rostime representing where to start in the bag.",
     )
@@ -49,7 +48,7 @@ def argparser_common(which_output):
         "--end",
         "-e",
         action="store",
-        default=sys.maxsize,
+        default=None,
         type=float,
         help="Rostime representing where to stop in the bag.",
     )
@@ -89,7 +88,7 @@ def parse_and_validate(parser):
 
     logging.info(f"Movie will contain topics: {args.topic}")
 
-    if args.start > args.end:
+    if args.start and args.end and args.start > args.end:
         parser.error("Start time is after stop time.")
 
     if args.index >= len(args.topic):

--- a/rosbags2video/bag2images.py
+++ b/rosbags2video/bag2images.py
@@ -5,7 +5,6 @@ import numpy as np
 from rosbags.highlevel import AnyReader
 from rosbags.image import message_to_cvimage
 from timeit import default_timer as timer
-import sys
 import os
 import imageio
 import logging
@@ -26,8 +25,8 @@ def write_frames(
     outdir,
     topics,
     sizes,
-    start_time=0,
-    stop_time=sys.maxsize,
+    start_time=None,
+    stop_time=None,
     viz=False,
     encoding="bgr8",
     skip=1,
@@ -44,12 +43,18 @@ def write_frames(
 
     pending = []
 
+    if start_time:
+        start_time = sec_to_ns(start_time)
+
+    if stop_time:
+        stop_time = sec_to_ns(stop_time)
+
     with ThreadPoolExecutor(max_workers=2) as executor:
         connections = [x for x in bag_reader.connections if x.topic in topics]
         for connection, t, rawdata in bag_reader.messages(
             connections=connections,
-            start=sec_to_ns(start_time),
-            stop=sec_to_ns(stop_time),
+            start=start_time,
+            stop=stop_time,
         ):
             topic = connection.topic
             msg = bag_reader.deserialize(rawdata, connection.msgtype)

--- a/rosbags2video/bag2video.py
+++ b/rosbags2video/bag2video.py
@@ -7,7 +7,6 @@ from timeit import default_timer as timer
 from pathlib import Path
 from datetime import datetime
 import numpy as np
-import sys
 import os
 import cv2
 import logging
@@ -25,8 +24,8 @@ def write_frames(
     fps,
     viz,
     encoding="bgr8",
-    start_time=0,
-    stop_time=sys.maxsize,
+    start_time=None,
+    stop_time=None,
     add_timestamp=False,
     use_bagtime=False,
 ):
@@ -44,9 +43,15 @@ def write_frames(
 
     init = True
 
+    if start_time:
+        start_time = sec_to_ns(start_time)
+
+    if stop_time:
+        stop_time = sec_to_ns(stop_time)
+
     connections = [x for x in bag_reader.connections if x.topic in topics]
     for connection, t, rawdata in bag_reader.messages(
-        connections=connections, start=sec_to_ns(start_time), stop=sec_to_ns(stop_time)
+        connections=connections, start=start_time, stop=stop_time
     ):
         topic = connection.topic
         msg = bag_reader.deserialize(rawdata, connection.msgtype)
@@ -147,6 +152,9 @@ def main():
             fps = args.fps
             if not fps:
                 logging.info("Calculating ideal output framerate.")
+                logging.info(f"Start time: {args.start}")
+                logging.info(f"End time: {args.end}")
+
                 fps = rosbags2video.get_frequency(
                     bag_reader, args.topic, args.start, args.end
                 )

--- a/rosbags2video/utils.py
+++ b/rosbags2video/utils.py
@@ -69,7 +69,13 @@ def get_sizes(bag_reader, topics=None, index=0, scale=1.0):
     return sizes
 
 
-def get_frequency(bag_reader, topics=None, start_time=0, stop_time=sys.maxsize):
+def get_frequency(bag_reader, topics=None, start_time=None, stop_time=None):
+    if start_time is None:
+        start_time = bag_reader.start_time / 1e9
+
+    if stop_time is None:
+        stop_time = bag_reader.end_time / 1e9
+
     # uses the highest topic message frequency as framerate
     duration = min(10.0e-10 * bag_reader.duration, (stop_time - start_time))
     highest_freq = 0


### PR DESCRIPTION
## Changes Made

In multiple places, "0" is used to indicate "no start time given", and "sys.maxsize" is used as "no stop time given."  However sqlite3 cannot handle Python's "sys.maxsize", and the script crashes on ROS2 sqlite3 bags.

Instead, use "None" to indicate "start / end time is not set", modify code as necessary.   This is how `rosbags.AnyReader` indicates "not set" for these two parameters, so this change is automatically consistent with rosbags.

## Associated Issues

- Fixes #17 

## Testing

Please provide a clear and concise description of the testing performed.
