### PR TITLE
Add option for timestamp-to-image correlation file

### DIFF
--- a/rosbags2video/args.py
+++ b/rosbags2video/args.py
@@ -173,4 +173,10 @@ def images_argparser():
         help="Encoding of the deserialized image. Default bgr8.",
     )
 
+    parser.add_argument(
+        "--timestamp-file",
+        type=Path,
+        help="Generate a file which correlates timestamp with filename",
+    )
+
     return parse_and_validate(parser)


### PR DESCRIPTION
## Changes Made

Adds an option `--timestamp-file [path]` to bag2images.   This produces a space-delimited file which lists timestamp (by default `header.stamp`) (in seconds) and filename.   For example:

```
# Timestamp_sec  filename
1748014051.1359491 image_000000.png
1748014051.2327247 image_000001.png
1748014051.3333719 image_000002.png
1748014051.4510932 image_000003.png
1748014051.5351334 image_000004.png
```


